### PR TITLE
Bump gpodder to 3.10.7

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -50,6 +50,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.10.7" date="2019-02-02"/>
     <release version="3.10.4" date="2018-09-09"/>
     <release version="3.10.3" date="2018-06-14"/>
   </releases>

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -113,6 +113,7 @@
         "mv $FLATPAK_DEST/share/applications/gpodder-url-handler.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.gpodder-url-handler.desktop"
       ],
       "post-install": [
+        "rm -fr $FLATPAK_DEST/share/icons/hicolor/16x16/apps/gpodder.ico",
         "install -Dm644 appdata.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.appdata.xml"
       ]
     }

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -99,8 +99,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/gpodder/gpodder/archive/3.10.4.tar.gz",
-          "sha256": "54613170d12feaa51f245271ee508403eed394c31402b342fee83281e1854cfa"
+          "url": "https://github.com/gpodder/gpodder/archive/3.10.7.tar.gz",
+          "sha256": "85a7beec3f63c6768c811482ad6e934b0527c29f03e903ca0f82d2e764cdad76"
         },
         {
           "type": "file",


### PR DESCRIPTION
Hello,
Gpodder is updated at a fair pace, so often one gets warnings within the app that the version is use if outdatated.
I thought I'd try updating the flatpak stuff.. sorry, if this is completely wrong, its basically just a search and replace of `3.10.4` for `3.10.7`
