### PR TITLE
Update to gpodder 3.10.8

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -50,6 +50,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.10.8" date="2019-04-08"/>
     <release version="3.10.7" date="2019-02-02"/>
     <release version="3.10.4" date="2018-09-09"/>
     <release version="3.10.3" date="2018-06-14"/>

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -99,8 +99,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/gpodder/gpodder/archive/3.10.7.tar.gz",
-          "sha256": "85a7beec3f63c6768c811482ad6e934b0527c29f03e903ca0f82d2e764cdad76"
+          "url": "https://github.com/gpodder/gpodder/archive/3.10.8.tar.gz",
+          "sha256": "eb84826194a15749ea8ea5b3e739b98a8f4f524907d0ebd0947cc484fa84f258"
         },
         {
           "type": "file",
@@ -113,7 +113,6 @@
         "mv $FLATPAK_DEST/share/applications/gpodder-url-handler.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.gpodder-url-handler.desktop"
       ],
       "post-install": [
-        "rm -fr $FLATPAK_DEST/share/icons/hicolor/16x16/apps/gpodder.ico",
         "install -Dm644 appdata.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.appdata.xml"
       ]
     }


### PR DESCRIPTION
Updated to latest gpodder version (3.10.8)
Remove `rm` from postinstall as upstream removed this file for us :)