### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,62 @@
+From 16f56355343ecbca771fbd73d529779e8dde073c Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Mon, 18 Nov 2024 18:16:40 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+Fix some issues.
+---
+ share/metainfo/org.gpodder.gpodder.appdata.xml | 33 ++++-----------------------------
+ 1 file changed, 4 insertions(+), 29 deletions(-)
+
+diff --git a/share/metainfo/org.gpodder.gpodder.appdata.xml b/share/metainfo/org.gpodder.gpodder.appdata.xml
+index 98ca26f..ac0a00b 100644
+--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
++++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
+@@ -10,40 +10,15 @@
+     <p>You can also take advantage of the service gpodder.net, which lets you sync subscriptions, playback progress and starred episodes.</p>
+   </description>
+   <launchable type="desktop-id">org.gpodder.gpodder.desktop</launchable>
++  <developer_name>The gPodder Team</developer_name>
+   <url type="homepage">https://www.gpodder.org</url>
++  <url type="bugtracker">https://github.com/gpodder/gpodder/issues</url>
++  <url type="vcs-browser">https://github.com/gpodder/gpodder</url>
+   <provides>
+     <binary>gpodder</binary>
+     <id>gpodder.desktop</id>
+   </provides>
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1"/>
+   <screenshots>
+     <screenshot type="default">
+       <caption>The main window</caption>
+--
+libgit2 1.7.2
+

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gpodder.gpodder",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "gpodder",
   "rename-icon": "gpodder",

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -41,6 +41,10 @@
           "type": "archive",
           "url": "https://github.com/gpodder/gpodder/archive/refs/tags/3.11.4.tar.gz",
           "sha256": "8022a6c29157dc287b5661f8915d04404767c33b6858e8d1a6c728904f8dae55"
+        },
+        {
+          "type": "patch",
+          "path": "fix-appdata.patch"
         }
       ],
       "buildsystem": "simple",


### PR DESCRIPTION
- GNOME runtime version 45 has reached EOL.
- Fix appdata papercuts.