### PR TITLE
Update to Gnome runtime 47

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,62 @@
+From 16f56355343ecbca771fbd73d529779e8dde073c Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Mon, 18 Nov 2024 18:16:40 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+Fix some issues.
+---
+ share/metainfo/org.gpodder.gpodder.appdata.xml | 33 ++++-----------------------------
+ 1 file changed, 4 insertions(+), 29 deletions(-)
+
+diff --git a/share/metainfo/org.gpodder.gpodder.appdata.xml b/share/metainfo/org.gpodder.gpodder.appdata.xml
+index 98ca26f..ac0a00b 100644
+--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
++++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
+@@ -10,40 +10,15 @@
+     <p>You can also take advantage of the service gpodder.net, which lets you sync subscriptions, playback progress and starred episodes.</p>
+   </description>
+   <launchable type="desktop-id">org.gpodder.gpodder.desktop</launchable>
++  <developer_name>The gPodder Team</developer_name>
+   <url type="homepage">https://www.gpodder.org</url>
++  <url type="bugtracker">https://github.com/gpodder/gpodder/issues</url>
++  <url type="vcs-browser">https://github.com/gpodder/gpodder</url>
+   <provides>
+     <binary>gpodder</binary>
+     <id>gpodder.desktop</id>
+   </provides>
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1"/>
+   <screenshots>
+     <screenshot type="default">
+       <caption>The main window</caption>
+--
+libgit2 1.7.2
+

--- a/importlib.patch
+++ b/importlib.patch
@@ -1,0 +1,47 @@
+From dd9b594d24a541c0f1d3b096e47b6d7f1c11ca7e Mon Sep 17 00:00:00 2001
+From: auouymous <au@qzx.com>
+Date: Fri, 20 Oct 2023 03:03:01 -0600
+Subject: [PATCH] Replace the removed imp module with importlib.
+
+---
+ src/gpodder/extensions.py | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/src/gpodder/extensions.py b/src/gpodder/extensions.py
+index 8f50ff31..44fc35d5 100644
+--- a/src/gpodder/extensions.py
++++ b/src/gpodder/extensions.py
+@@ -31,7 +31,7 @@ For an example extension see share/gpodder/examples/extensions.py
+ 
+ import functools
+ import glob
+-import imp
++import importlib
+ import logging
+ import os
+ import re
+@@ -291,15 +291,16 @@ class ExtensionContainer(object):
+                     self.name, self.metadata.only_for)
+             return
+ 
+-        basename, extension = os.path.splitext(os.path.basename(self.filename))
+-        fp = open(self.filename, 'r')
++        basename, _ = os.path.splitext(os.path.basename(self.filename))
+         try:
+-            module_file = imp.load_module(basename, fp, self.filename,
+-                    (extension, 'r', imp.PY_SOURCE))
++            # from load_source() on https://docs.python.org/dev/whatsnew/3.12.html
++            loader = importlib.machinery.SourceFileLoader(basename, self.filename)
++            spec = importlib.util.spec_from_file_location(basename, self.filename, loader=loader)
++            module_file = importlib.util.module_from_spec(spec)
++            loader.exec_module(module_file)
+         finally:
+             # Remove the .pyc file if it was created during import
+             util.delete_file(self.filename + 'c')
+-        fp.close()
+ 
+         self.default_config = getattr(module_file, 'DefaultConfig', {})
+         if self.default_config:
+-- 
+2.45.2
+

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gpodder.gpodder",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "gpodder",
   "rename-icon": "gpodder",
@@ -45,6 +45,10 @@
         {
           "type": "patch",
           "path": "fix-appdata.patch"
+        },
+        {
+          "type": "patch",
+          "path": "importlib.patch"
         }
       ],
       "buildsystem": "simple",

--- a/org.gpodder.gpodder.json
+++ b/org.gpodder.gpodder.json
@@ -41,6 +41,10 @@
           "type": "archive",
           "url": "https://github.com/gpodder/gpodder/archive/refs/tags/3.11.4.tar.gz",
           "sha256": "8022a6c29157dc287b5661f8915d04404767c33b6858e8d1a6c728904f8dae55"
+        },
+        {
+          "type": "patch",
+          "path": "fix-appdata.patch"
         }
       ],
       "buildsystem": "simple",

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -65,45 +65,6 @@
             ]
         },
         {
-            "name": "python3-requests",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests[socks]==2.31.0\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl",
-                    "sha256": "2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl",
-                    "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz",
-                    "sha256": "63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
-                    "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
-                    "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/26/40/9957270221b6d3e9a3b92fdfba80dd5c9661ff45a664b47edd5d00f707f5/urllib3-2.0.6-py3-none-any.whl",
-                    "sha256": "7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"
-                }
-            ]
-        },
-        {
             "name": "python3-urllib3",
             "buildsystem": "simple",
             "build-commands": [
@@ -118,6 +79,96 @@
             ]
         },
         {
+            "name": "python3-brotli",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"brotli\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/2f/c2/f9e977608bdf958650638c3f1e28f85a1b075f075ebbe77db8555463787b/Brotli-1.1.0.tar.gz",
+                    "sha256": "81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724"
+                }
+            ]
+        },
+        {
+            "name": "python3-certifi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"certifi\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl",
+                    "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"
+                }
+            ]
+        },
+        {
+            "name": "python3-pycryptodomex",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pycryptodomex\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/11/dc/e66551683ade663b5f07d7b3bc46434bf703491dbd22ee12d1f979ca828f/pycryptodomex-3.21.0.tar.gz",
+                    "sha256": "222d0bd05381dd25c32dd6065c071ebf084212ab79bab4599ba9e6a3e0009e6c"
+                }
+            ]
+        },
+        {
+            "name": "python3-requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests>=2.32.2,<3\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl",
+                    "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz",
+                    "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
+                    "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
+                    "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/26/40/9957270221b6d3e9a3b92fdfba80dd5c9661ff45a664b47edd5d00f707f5/urllib3-2.0.6-py3-none-any.whl",
+                    "sha256": "7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"
+                }
+            ]
+        },
+        {
+            "name": "python3-websockets",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"websockets\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f4/1b/380b883ce05bb5f45a905b61790319a28958a9ab1e4b6b95ff5464b60ca1/websockets-14.1.tar.gz",
+                    "sha256": "398b10c77d471c0aab20a845e7a60076b6390bfdaac7a6d2edb0d2c59d75e8d8"
+                }
+            ]
+        },
+        {
             "name": "python3-yt-dlp",
             "buildsystem": "simple",
             "build-commands": [
@@ -126,33 +177,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/2f/c2/f9e977608bdf958650638c3f1e28f85a1b075f075ebbe77db8555463787b/Brotli-1.1.0.tar.gz",
-                    "sha256": "81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl",
-                    "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/03/ee/114d7016d2e34f341e212fefb5e7bd87785077ebcfff0ad23a497c70eea1/mutagen-1.46.0-py3-none-any.whl",
-                    "sha256": "8af0728aa2d5c3ee5a727e28d0627966641fddfe804c23eabb5926a4d770aed5"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/14/c9/09d5df04c9f29ae1b49d0e34c9934646b53bb2131a55e8ed2a0d447c7c53/pycryptodomex-3.19.0.tar.gz",
-                    "sha256": "af83a554b3f077564229865c45af0791be008ac6469ef0098152139e6bd4b5b6"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d8/3b/2ed38e52eed4cf277f9df5f0463a99199a04d9e29c9e227cfafa57bd3993/websockets-11.0.3.tar.gz",
-                    "sha256": "88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/9a/24/9ba3bbcc12a059dbb484e16309926cf2676212efe9320dd35592322b5b97/yt_dlp-2023.10.7-py2.py3-none-any.whl",
-                    "sha256": "5f5253aec0a7e18c991d7412ee293eee99f73249b360f4adb9a3f529b769d9d9"
+                    "url": "https://files.pythonhosted.org/packages/64/22/1918d2c8c123e9157efd7c2063ea89b4826f904d67b17e77152862ac3347/yt_dlp-2024.11.18-py3-none-any.whl",
+                    "sha256": "b9741695911dc566498b5f115cdd6b1abbc5be61cb01fd98abe649990a41656c"
                 }
             ]
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,20 @@
+# Combined gPodder and yt-dlp python dependencies
+# yt-dlp does not have requirements.txt any more (deps are in pyproject.toml,
+# which flatpak-pip generator does not support), so we list its missing
+# dependencies here.
+#
+# gPodder dependencies
+# dbus-python is in the main build manifest
+html5lib==1.1
+mutagen==1.46.0
+mygpoclient==1.9
+podcastparser==0.6.10
+# requests[socks]==2.31.0  # Use the later requests from yt-dlp
+urllib3==2.0.6
+# yt-dlp + deps
+brotli
+certifi
+pycryptodomex
+requests>=2.32.2,<3
+websockets
+yt-dlp


### PR DESCRIPTION
Update Gnome runtime and python dependencies.

Python 3.12 in Gnome 47 runtime removed the `imp` module, a patch replacing it with `importlib` is backported from gPodder git.

Also add appdata patch from @yakushabb.